### PR TITLE
VSCodeの推奨設定を追加

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "bradlc.vscode-tailwindcss",
+    "zignd.html-css-class-completion",
+    "unifiedjs.vscode-mdx",
+    "shd101wyy.markdown-preview-enhanced"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,57 @@
+{
+    "editor.tabSize": 2,
+    "eslint.format.enable": true,
+    "eslint.rules.customizations": [
+        {
+            "rule": "@stylistic/*",
+            "fixable": true,
+            "severity": "info"
+        }
+    ],
+    "eslint.useFlatConfig": true,
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": "explicit"
+    },
+    "eslint.codeActionsOnSave.mode": "all",
+    "eslint.codeActionsOnSave.rules": [
+        "@stylistic/*"
+    ],
+    "[javascript]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    },
+    "[javascriptreact]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    },
+    "[typescript]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    },
+    "[typescriptreact]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    },
+    "[markdown]": {
+        "editor.defaultFormatter": "unifiedjs.vscode-mdx",
+        "files.trimTrailingWhitespace": false,
+        "editor.unicodeHighlight.ambiguousCharacters": false,
+        "editor.unicodeHighlight.invisibleCharacters": false,
+        "diffEditor.ignoreTrimWhitespace": false,
+        "editor.wordWrap": "on",
+        "editor.quickSuggestions": {
+            "comments": "off",
+            "strings": "off",
+            "other": "off"
+        }
+    },
+    "[mdx]": {
+        "editor.defaultFormatter": "unifiedjs.vscode-mdx",
+        "files.trimTrailingWhitespace": false,
+        "editor.unicodeHighlight.ambiguousCharacters": false,
+        "editor.unicodeHighlight.invisibleCharacters": false,
+        "diffEditor.ignoreTrimWhitespace": false,
+        "editor.wordWrap": "on",
+        "editor.quickSuggestions": {
+            "comments": "off",
+            "strings": "off",
+            "other": "off"
+        }
+    }
+}


### PR DESCRIPTION
- いくつかの拡張機能を推奨事項に追加（ESLint、TailwindCSS、Markdown関係）
- 保存時にESLintの`@stylistic/*`のルールを適用するように
- `@stylistic/*`のルールは違反していても赤線ではなく青線で表示されるように
- `tsx`ファイルなどのフォーマッタを構成。`mdx`も同様に