### PR TITLE
スマホでのヘッダーの改善

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-sans">
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start bg-red-100">
         <Image
           className="dark:invert"
@@ -11,7 +11,7 @@ export default function Home() {
           width={180}
           height={38}
           priority />
-        <ol className="list-inside list-decimal text-sm text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
+        <ol className="list-inside list-decimal text-sm text-center sm:text-left font-mono">
           <li className="mb-2">
             Get started by editing{' '}
             <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-semibold">

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-sans">
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start bg-blue-100">
         <Image
           className="dark:invert"
@@ -11,7 +11,7 @@ export default function Home() {
           width={180}
           height={38}
           priority />
-        <ol className="list-inside list-decimal text-sm text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
+        <ol className="list-inside list-decimal text-sm text-center sm:text-left font-mono">
           <li className="mb-2">
             Get started by editing{' '}
             <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-semibold">

--- a/app/globals.css
+++ b/app/globals.css
@@ -17,7 +17,6 @@
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
 }
 
 .prose {

--- a/app/globals.css
+++ b/app/globals.css
@@ -20,18 +20,6 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
-@layer utilities {
-  .text-balance {
-    text-wrap: balance;
-  }
-}
-
-.nav a {
-  @apply block min-w-max h-full px-8 text-center content-center max-md:px-0 max-lg:px-4;
-  @apply text-white hocus:text-black transition-all duration-500 ease-in-out;
-  @apply [box-shadow:inset_0_-2px_white] hocus:[box-shadow:inset_0_calc(-1*theme(spacing.24))_white] max-md:hocus:[box-shadow:inset_0_calc(-1*theme(spacing.12))_white];
-}
-
 .prose {
   :is(h1, h2, h3, h4, h5, h6) {
     @apply relative before:content-["#"] before:me-1;
@@ -55,18 +43,12 @@ body {
   }
 }
 
-:is(code, pre)[data-theme*=" "],
-:is(code, pre)[data-theme*=" "] span {
-  color: var(--shiki-light);
-  background-color: var(--shiki-light-bg);
+:is(code, pre)[data-theme*=" "] {
+  @apply bg-[--shiki-light-bg] dark:bg-[--shiki-dark-bg];
 }
 
-@media (prefers-color-scheme: dark) {
-  :is(code, pre)[data-theme*=" "],
-  :is(code, pre)[data-theme*=" "] span {
-    color: var(--shiki-dark);
-    background-color: var(--shiki-dark-bg);
-  }
+:is(code, pre)[data-theme*=" "] span {
+  @apply text-[--shiki-light] dark:text-[--shiki-dark];
 }
 
 :root { --tw-color-scheme: light; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -63,38 +63,34 @@ export default function RootLayout({
           <Link href="/" className="flex flex-row align-baseline max-md:hidden">
             <Image src={logo_dark} alt="二部ソフトウェア研究部" className="w-64" />
           </Link>
-          <a
-            className="flex items-center hover:underline underline-offset-4"
-            href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer">
-            <span className="icon-mslight-document-search-outline size-4 me-2" />
-            Learn
-          </a>
-          <a
-            className="flex items-center hover:underline underline-offset-4"
-            href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer">
-            <span className="icon-mslight-select-window-2-outline me-2" />
-            Examples
-          </a>
-          <a
-            className="flex items-center hover:underline underline-offset-4"
-            href="https://github.com/sofken2/sofken2"
-            target="_blank"
-            rel="noopener noreferrer">
-            <span className="icon-uit-github-alt me-2" />
-            GitHub
-          </a>
-          <a
-            className="flex items-center hover:underline underline-offset-4"
-            href="https://x.com/sofken2"
-            target="_blank"
-            rel="noopener noreferrer">
-            <span className="icon-uit-twitter-alt me-2" />
-            Twitter
-          </a>
+          {([{
+            title: 'Learn',
+            href: 'https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app',
+            icon: 'icon-mslight-document-search-outline',
+          }, {
+            title: 'Example',
+            href: 'https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app',
+            icon: 'icon-mslight-select-window-2-outline',
+          }, {
+            title: 'GitHub',
+            href: 'https://github.com/sofken2/sofken2',
+            icon: 'icon-uit-github-alt',
+          }, {
+            title: 'Twitter',
+            href: 'https://x.com/sofken2',
+            icon: 'icon-uit-twitter-alt',
+          }] as const).map(({ title, href, icon }) => (
+            <a
+              key={title}
+              className="flex items-center hover:underline underline-offset-4"
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer">
+              <span className={`${icon} size-4 me-2`} />
+              {title}
+              <span className="icon-mslight-open-in-new size-4" />
+            </a>
+          ))}
         </footer>
 
         {(preview) && <label className="fixed bottom-4 right-4 w-max self-center p-2 bg-[repeating-linear-gradient(135deg,black_0px,black_20px,yellow_20px,yellow_40px)] transition-all duration-500 has-[#preview-tip:checked]:translate-x-full has-[#preview-tip:checked]:opacity-20 cursor-pointer">
@@ -122,7 +118,8 @@ export default function RootLayout({
           ] as const).map(([name, icon, desc, checked]) => (
             <label key={name} className="size-8 p-1.5 rounded-full cursor-pointer relative group">
               <input type="radio" name="color-scheme" className="absolute inset-0 rounded-full appearance-none" id={name} defaultChecked={checked} />
-              <span className="absolute inset-y-0 -left-2 m-auto px-2 size-max -translate-x-full invisible group-hover:visible bg-black/80 rounded-full text-sm device-touch:group-active:delay-0 device-touch:group-has-[:checked]:delay-1000 select-none">{desc}</span>
+              <span className="sr-only">{desc}</span>
+              <span aria-hidden="true" className="absolute inset-y-0 -left-2 m-auto px-2 size-max -translate-x-full invisible group-hover:visible bg-black/80 rounded-full text-sm device-touch:group-active:delay-0 device-touch:group-has-[:checked]:delay-1000 select-none">{desc}</span>
               <span className={`size-full ${icon} group-hover:scale-125 transition-all`} />
             </label>
           ))}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,14 +2,23 @@ import type { Metadata } from 'next';
 import './globals.css';
 import Link from 'next/link';
 import Image from 'next/image';
-import { M_PLUS_1p } from 'next/font/google';
+import { M_PLUS_1p, M_PLUS_1, Source_Sans_3 } from 'next/font/google';
 
 import { logo_dark } from './res/logo';
+import { clsx } from './utils';
 
-const mplus = M_PLUS_1p({
+const mplusp = M_PLUS_1p({
   variable: '--font-mplus-1p',
   subsets: ['latin'],
   weight: ['100', '300', '400', '500', '700', '800', '900'],
+});
+const mplus = M_PLUS_1({
+  variable: '--font-mplus-1',
+  subsets: ['latin'],
+});
+const source = Source_Sans_3({
+  variable: '--font-source-sans',
+  subsets: ['latin'],
 });
 
 export const metadata: Metadata = {
@@ -27,18 +36,22 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ja" className={`scroll-container${(development || preview) ? ' has-[#theme-dark:checked]:[color-scheme:dark] has-[#theme-dark:checked]:[--tw-color-scheme:dark] has-[#theme-light:checked]:[color-scheme:light] has-[#theme-light:checked]:[--tw-color-scheme:light]' : ''}`}>
-      <body className={`min-h-screen ${mplus.variable} font-sans font-light antialiased bg-[url('https://picsum.photos/seed/eternalcore/1920/1200?grayscale')] bg-cover`}>
+    <html lang="ja" className={clsx(`scroll-container`, (development || preview) && 'has-[#theme-dark:checked]:[color-scheme:dark] has-[#theme-dark:checked]:[--tw-color-scheme:dark] has-[#theme-light:checked]:[color-scheme:light] has-[#theme-light:checked]:[--tw-color-scheme:light]')}>
+      <body className={`min-h-screen bg-[url('https://picsum.photos/seed/eternalcore/1920/1200?grayscale')] bg-cover font-sans font-light antialiased ${mplus.variable} ${mplusp.variable} ${source.variable}`}>
 
         <header className="flex flex-row fixed inset-x-0 top-0 z-10 text-white backdrop-blur-sm backdrop-brightness-50 border-b-white border-b-2 max-md:flex-col max-md:items-center max-md:not-at-page-top:-translate-y-24 transition-all delay-200 duration-500">
           <Link href="/" className="h-24 md:not-at-page-top:h-16 transition-all delay-200 duration-500">
             <Image src={logo_dark} alt="二部ソフトウェア研究部" className="px-16 py-4 h-full w-fit object-contain md:not-at-page-top:py-2 md:not-at-page-top:px-24 transition-all delay-200 duration-500" />
           </Link>
-          <ul className="nav h-24 ms-auto flex flex-row gap-1 max-md:h-12 *:max-md:flex-1 max-md:w-full border-white max-md:border-t-[1px] not-at-page-top:h-16 transition-all  delay-200 duration-500">
-            <li><Link href="/about">About Us</Link></li>
-            <li><Link href="/news">News</Link></li>
-            <li><Link href="/blog">Blog</Link></li>
-            <li><Link href="/contact">Contact</Link></li>
+          <ul className="h-24 ms-auto flex flex-row gap-1 max-md:h-12 *:max-md:flex-1 max-md:w-full border-white max-md:border-t-[1px] not-at-page-top:h-16 transition-all delay-200 duration-500">
+            {([
+              ['/about', 'About Us'],
+              ['/news', 'News'],
+              ['/blog', 'Blog'],
+              ['/contact', 'Contact'],
+            ] as const).map(([href, name]) => (<li key={href}>
+              <Link href={href} className="block min-w-max h-full px-8 text-center content-center max-md:px-0 max-lg:px-4 text-white hocus:text-black transition-all duration-500 ease-in-out [box-shadow:inset_0_var(--sw)_white] [--sw:-2px] hocus:[--sw:calc(-1*theme('spacing.24'))] max-md:hocus:[--sw:calc(-1*theme('spacing.12'))] device-touch:[--sw:-4px] device-touch:active:[--sw:-1px] device-touch:duration-200">{name}</Link>
+            </li>))}
           </ul>
         </header>
 
@@ -84,46 +97,44 @@ export default function RootLayout({
           </a>
         </footer>
 
-        {preview && <label className="fixed bottom-4 right-4 w-min self-center p-2 bg-[repeating-linear-gradient(135deg,black_0px,black_20px,yellow_20px,yellow_40px)] transition-all duration-500 has-[#preview-tip:checked]:translate-x-full has-[#preview-tip:checked]:opacity-20 cursor-pointer">
-          <input type="checkbox" id="preview-tip" name="hide-preview-tip" className="sr-only" />
-          <span className="flex flex-row items-center self-center bg-slate-600 px-2 py-1 text-white">
-            <span className="icon-material-symbols-light-construction text-4xl me-2"></span>
-            <span className="first-line:text-lg first-line:leading-none text-xs w-min">Preview<br />Under Construction</span>
-          </span>
+        {(preview) && <label className="fixed bottom-4 right-4 w-max self-center p-2 bg-[repeating-linear-gradient(135deg,black_0px,black_20px,yellow_20px,yellow_40px)] transition-all duration-500 has-[#preview-tip:checked]:translate-x-full has-[#preview-tip:checked]:opacity-20 cursor-pointer">
+          <input type="checkbox" id="preview-tip" name="hide-preview-tip" className="absolute inset-0 appearance-none cursor-pointer" />
+          <div className="flex flex-row items-center self-center bg-slate-600 px-2 py-1 text-white">
+            <span className="icon-mslight-construction text-4xl me-2"></span>
+            <div>
+              <div className="text-lg leading-none">Preview</div>
+              <div className="text-xs">Under Construction</div>
+            </div>
+          </div>
         </label>}
 
-        {false && <div className="fixed inset-0 m-auto size-max text-4xl select-none">
+        {(false) && <div className="fixed inset-0 m-auto size-max text-4xl select-none">
           <span className="sm:after:content-['sm'] md:after:content-['md'] lg:after:content-['lg'] xl:after:content-['xl']" />
           <span> / </span>
           <span className="max-sm:after:content-['max-sm'] max-md:after:content-['max-md'] max-lg:after:content-['max-lg'] max-xl:after:content-['max-xl']" />
         </div>}
 
-        {(development || preview) && <div className="fixed inset-y-0 right-4 m-auto size-10 p-1 bg-black text-white bg-opacity-75 [&_input]:sr-only group/theme">
-          <label className="sr-only group-has-[#theme-light:checked]/theme:not-sr-only cursor-pointer">
-            <input type="radio" name="color-scheme" id="theme-system" defaultChecked />
-            <span className="size-8 icon-mslight-brightness-auto-outline"></span>
-          </label>
-          <label className="sr-only group-has-[#theme-system:checked]/theme:not-sr-only cursor-pointer">
-            <input type="radio" name="color-scheme" id="theme-dark" />
-            <span className="size-8 icon-mslight-light-mode-outline"></span>
-          </label>
-          <label className="sr-only group-has-[#theme-dark:checked]/theme:not-sr-only cursor-pointer">
-            <input type="radio" name="color-scheme" id="theme-light" />
-            <span className="size-8 icon-mslight-dark-mode-outline"></span>
-          </label>
+        {(development || preview) && <div className="flex flex-col fixed inset-y-0 right-4 m-auto size-min p-1 bg-black/80 text-white rounded-full -space-y-1 before:absolute before:inset-x-0 before:size-8 before:m-1 before:rounded-full before:bg-white/20 has-[#theme-light:checked]:before:top-0 has-[#theme-system:checked]:before:top-[1.75rem] has-[#theme-dark:checked]:before:top-[3.5rem] before:transition-all">
+          {([
+            ['theme-light', 'icon-mslight-light-mode-outline', 'Light Mode'],
+            ['theme-system', 'icon-mslight-display-settings-outline', 'No Override', true],
+            ['theme-dark', 'icon-mslight-dark-mode-outline', 'Dark Mode'],
+          ] as const).map(([name, icon, desc, checked]) => (
+            <label key={name} className="size-8 p-1.5 rounded-full cursor-pointer relative group">
+              <input type="radio" name="color-scheme" className="absolute inset-0 rounded-full appearance-none" id={name} defaultChecked={checked} />
+              <span className="absolute inset-y-0 -left-2 m-auto px-2 size-max -translate-x-full invisible group-hover:visible bg-black/80 rounded-full text-sm device-touch:group-active:delay-0 device-touch:group-has-[:checked]:delay-1000 select-none">{desc}</span>
+              <span className={`size-full ${icon} group-hover:scale-125 transition-all`} />
+            </label>
+          ))}
         </div>}
 
-        {(development || preview) && <label className="fixed inset-y-0 left-4 m-auto size-max min-w-40 p-1 bg-black text-white bg-opacity-75 transition-all duration-500 has-[#scroll-tip:checked]:-translate-x-full has-[#scroll-tip:checked]:opacity-20 has-[#scroll-tip:checked]:pe-4 cursor-pointer">
-          <input type="checkbox" id="scroll-tip" name="hide-scroll-tip" className="sr-only" defaultChecked />
+        {(development || preview) && <label className="flex flex-col gap-1 fixed inset-y-0 left-4 m-auto size-max min-w-40 p-1 bg-black/80 text-white transition-all duration-500 has-[#scroll-tip:checked]:-translate-x-full has-[#scroll-tip:checked]:opacity-20 has-[#scroll-tip:checked]:pe-4 cursor-pointer">
+          <input type="checkbox" id="scroll-tip" name="hide-scroll-tip" className="absolute inset-0 appearance-none cursor-pointer" defaultChecked />
 
-          <div className="w-full relative after:absolute after:inset-x-0 after:bottom-0 after:h-[1px] after:bg-white after:origin-left after:scale-x-[--scroll-pos]">scroll-position</div>
-          <div className="w-full relative after:absolute after:right-0 after:left-1/2 after:bottom-0 after:h-[1px] after:bg-white after:origin-left after:scale-x-[--scroll-vel]">scroll-velocity</div>
-          <div className="not-scrolling:bg-white not-scrolling:text-black">state: stopped</div>
-          <div className="scrolling:bg-white scrolling:text-black">state: scrolling</div>
-          <div className="scrolling-up:bg-white scrolling-up:text-black">direction: up</div>
-          <div className="scrolling-down:bg-white scrolling-down:text-black">direction:-down</div>
-          <div className="at-page-top:bg-white at-page-top:text-black">scroll pos: top</div>
-          <div className="at-page-bottom:bg-white at-page-bottom:text-black">scroll pos: bottom</div>
+          <div className="w-full relative after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-current after:origin-left after:scale-x-[--scroll-pos]">scroll-position</div>
+          <div className="w-full relative after:absolute after:right-0 after:left-1/2 after:bottom-0 after:h-px after:bg-current after:origin-left after:scale-x-[--scroll-vel]">scroll-velocity</div>
+          <div className="scrolling-up:after:content-['up'] scrolling-down:after:content-['down'] not-scrolling:after:content-['stopped'] scrolling:text-black scrolling:bg-white">scroll dir: </div>
+          <div className="after:content-['middle'] at-page-top:after:content-['top'] at-page-top:text-black at-page-top:bg-white at-page-bottom:after:content-['bottom'] at-page-bottom:text-black at-page-bottom:bg-white">scroll pos: </div>
         </label>}
       </body>
     </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,24 +2,9 @@ import type { Metadata } from 'next';
 import './globals.css';
 import Link from 'next/link';
 import Image from 'next/image';
-import { M_PLUS_1p, M_PLUS_1, Source_Sans_3 } from 'next/font/google';
-
 import { logo_dark } from './res/logo';
 import { clsx } from './utils';
-
-const mplusp = M_PLUS_1p({
-  variable: '--font-mplus-1p',
-  subsets: ['latin'],
-  weight: ['100', '300', '400', '500', '700', '800', '900'],
-});
-const mplus = M_PLUS_1({
-  variable: '--font-mplus-1',
-  subsets: ['latin'],
-});
-const source = Source_Sans_3({
-  variable: '--font-source-sans',
-  subsets: ['latin'],
-});
+import { font_variables } from './res/fonts';
 
 export const metadata: Metadata = {
   title: '2部ソフ研',
@@ -36,8 +21,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ja" className={clsx(`scroll-container`, (development || preview) && 'has-[#theme-dark:checked]:[color-scheme:dark] has-[#theme-dark:checked]:[--tw-color-scheme:dark] has-[#theme-light:checked]:[color-scheme:light] has-[#theme-light:checked]:[--tw-color-scheme:light]')}>
-      <body className={`min-h-screen bg-[url('https://picsum.photos/seed/eternalcore/1920/1200?grayscale')] bg-cover font-sans font-light antialiased ${mplus.variable} ${mplusp.variable} ${source.variable}`}>
+    <html lang="ja" className={clsx(`scroll-container`, (development || preview) && 'has-[#theme-dark:checked]:[color-scheme:dark] has-[#theme-dark:checked]:[--tw-color-scheme:dark] has-[#theme-light:checked]:[color-scheme:light] has-[#theme-light:checked]:[--tw-color-scheme:light]', font_variables)}>
+      <body className="min-h-screen bg-[url('https://picsum.photos/seed/eternalcore/1920/1200?grayscale')] bg-cover font-sans font-light antialiased">
 
         <header className="flex flex-row fixed inset-x-0 top-0 z-10 text-white backdrop-blur-sm backdrop-brightness-50 border-b-white border-b-2 max-md:flex-col max-md:items-center max-md:not-at-page-top:-translate-y-24 transition-all delay-200 duration-500">
           <Link href="/" className="h-24 md:not-at-page-top:h-16 transition-all delay-200 duration-500">
@@ -55,11 +40,11 @@ export default function RootLayout({
           </ul>
         </header>
 
-        <main className="max-w-screen-sm min-h-full mx-auto bg-white bg-opacity-80 p-8 pt-24 -mb-60 pb-60 max-md:pt-36 max-md:max-w-full lg:max-w-screen-md dark:bg-slate-800">
+        <main className="max-w-screen-sm min-h-full mx-auto bg-white/80 p-8 pt-24 -mb-60 pb-60 max-md:pt-36 max-md:max-w-full lg:max-w-screen-md dark:bg-slate-800">
           {children}
         </main>
 
-        <footer className="h-60 flex flex-row gap-6 flex-wrap items-center justify-center backdrop-blur-sm backdrop-brightness-50 text-white">
+        <footer className="h-60 flex flex-row gap-6 flex-wrap items-center justify-center content-center backdrop-blur-sm backdrop-brightness-50 text-white">
           <Link href="/" className="flex flex-row align-baseline max-md:hidden">
             <Image src={logo_dark} alt="二部ソフトウェア研究部" className="w-64" />
           </Link>
@@ -80,15 +65,10 @@ export default function RootLayout({
             href: 'https://x.com/sofken2',
             icon: 'icon-uit-twitter-alt',
           }] as const).map(({ title, href, icon }) => (
-            <a
-              key={title}
-              className="flex items-center hover:underline underline-offset-4"
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer">
+            <a key={title} className="flex items-center hover:underline underline-offset-4" href={href} target="_blank" rel="noopener noreferrer">
               <span className={`${icon} size-4 me-2`} />
-              {title}
-              <span className="icon-mslight-open-in-new size-4" />
+              <span className="font-thin">{title}</span>
+              <span className="icon-mslight-open-in-new size-4 translate-y-px" />
             </a>
           ))}
         </footer>
@@ -98,7 +78,7 @@ export default function RootLayout({
           <div className="flex flex-row items-center self-center bg-slate-600 px-2 py-1 text-white">
             <span className="icon-mslight-construction text-4xl me-2"></span>
             <div>
-              <div className="text-lg leading-none">Preview</div>
+              <div className="text-lg/none">Preview</div>
               <div className="text-xs">Under Construction</div>
             </div>
           </div>
@@ -119,7 +99,7 @@ export default function RootLayout({
             <label key={name} className="size-8 p-1.5 rounded-full cursor-pointer relative group">
               <input type="radio" name="color-scheme" className="absolute inset-0 rounded-full appearance-none" id={name} defaultChecked={checked} />
               <span className="sr-only">{desc}</span>
-              <span aria-hidden="true" className="absolute inset-y-0 -left-2 m-auto px-2 size-max -translate-x-full invisible group-hover:visible bg-black/80 rounded-full text-sm device-touch:group-active:delay-0 device-touch:group-has-[:checked]:delay-1000 select-none">{desc}</span>
+              <span aria-hidden="true" className="absolute inset-y-0 -left-2 m-auto px-2 py-1 size-max -translate-x-full invisible group-hover:visible bg-black/80 rounded-full text-sm/none device-touch:group-active:delay-0 device-touch:group-has-[:checked]:delay-1000 select-none">{desc}</span>
               <span className={`size-full ${icon} group-hover:scale-125 transition-all`} />
             </label>
           ))}

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-sans">
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start bg-green-100">
         <Image
           className="dark:invert"
@@ -11,7 +11,7 @@ export default function Home() {
           width={180}
           height={38}
           priority />
-        <ol className="list-inside list-decimal text-sm text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
+        <ol className="list-inside list-decimal text-sm text-center sm:text-left font-mono">
           <li className="mb-2">
             Get started by editing{' '}
             <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-semibold">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 
 export default function Home() {
   return (
-    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
+    <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-sans">
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
         <Image
           className="dark:invert"
@@ -11,7 +11,7 @@ export default function Home() {
           width={180}
           height={38}
           priority />
-        <ol className="list-inside list-decimal text-sm text-center sm:text-left font-[family-name:var(--font-geist-mono)]">
+        <ol className="list-inside list-decimal text-sm text-center sm:text-left font-mono">
           <li className="mb-2">
             Get started by editing{' '}
             <code className="bg-black/[.05] dark:bg-white/[.06] px-1 py-0.5 rounded font-semibold">

--- a/app/res/fonts.ts
+++ b/app/res/fonts.ts
@@ -1,0 +1,53 @@
+import { Noto_Sans_JP } from 'next/font/google';
+import { clsx } from '../utils';
+
+// M_PLUS_1p => 1とほぼ同じでバリアブル非対応。Kazesawaはこちら？
+// M_PLUS_1
+// Source_Sans_3
+// Noto_Sans_JP
+// Inter => バリアブルで軸も多く確かに読みやすい
+// 游ゴシック
+
+// 游明朝
+// Source_Serif_4
+// Noto_Serif_JP
+
+// export const m_plus_1 = M_PLUS_1({
+//   variable: '--font-mplus-1',
+//   preload: false,
+//   display: 'swap',
+// });
+
+// export const source_sans = Source_Sans_3({
+//   variable: '--font-source-sans',
+//   preload: false,
+//   display: 'swap',
+// });
+// export const source_serif = Source_Serif_4({
+//   variable: '--font-source-serif',
+//   preload: false,
+//   display: 'swap',
+// });
+
+export const noto_sans = Noto_Sans_JP({
+  variable: '--font-noto-sans',
+  preload: false,
+});
+// export const noto_serif = Noto_Serif_JP({
+//   variable: '--font-noto-serif',
+//   preload: false,
+//   display: 'swap',
+// });
+
+// export const inter = Inter({
+//   variable: '--font-inter',
+//   preload: false,
+//   display: 'swap',
+// });
+
+export const font_variables = clsx([
+  // m_plus_1,
+  // source_sans,
+  noto_sans,
+  // noto_serif,
+].map((it) => it.variable));

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1,0 +1,11 @@
+type Falsy = '' | 0 | -0 | 0n | false | null | undefined;
+type MaybeArray<T> = T | T[];
+
+export const clsx = (...classes: MaybeArray<string | Falsy>[]): string | undefined => {
+  const list = classes
+    .flatMap((it) => Array.isArray(it) ? it : [it])
+    .flatMap((it) => it ? it.split(/\s+/) : [])
+    .filter((it) => it !== '');
+
+  return list.length > 0 ? list.join(' ') : undefined;
+};

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,10 @@ const eslintConfig = [
   {
     name: '@stylistic/override',
     rules: {
+      '@stylistic/quotes': ['error', 'single', {
+        'avoidEscape': true,
+        'allowTemplateLiterals': true,
+      }],
       '@stylistic/jsx-closing-tag-location': ['error', 'line-aligned'],
       '@stylistic/jsx-closing-bracket-location': ['error', 'after-props'],
       '@stylistic/jsx-one-expression-per-line': 'off',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,14 +2,8 @@ import type { Config } from 'tailwindcss';
 import defaultTheme from 'tailwindcss/defaultTheme';
 import typographyPlugin from '@tailwindcss/typography';
 import { getIconCollections, iconsPlugin } from '@egoist/tailwindcss-icons';
-import { type ResolvableTo } from 'tailwindcss/types/config';
-import { type CSSProperties } from 'react';
 import plugin from 'tailwindcss/plugin';
-
-const key = (w: '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900') => {
-  const [name] = Object.entries(defaultTheme.fontWeight ?? {}).find(([, value]) => value === w) ?? ['normal'];
-  return `fontWeight.${name}`;
-};
+import typographyConfig from './typography.config';
 
 const preview = process.env.deployment === 'preview';
 const development = process.env.NODE_ENV !== 'production';
@@ -37,8 +31,24 @@ const config = {
       },
     }),
     plugin(({ addVariant }) => {
-      addVariant('hover', '@media (hover: hover) { &:hover }');
-      addVariant('hocus', '@media (hover: hover) { &:is(:hover, :focus-visible) }');
+      addVariant('hover', [
+        '@media (hover: hover) { &:is(:hover, :focus-visible) }',
+        '@media (hover: none) { &:is(:active, :focus-visible) }',
+      ]);
+      addVariant('group-hover', [
+        '@media (hover: hover) { .group:is(:hover, :focus-visible) & }',
+        '@media (hover: none) { .group:is(:active, :focus-visible) & }',
+      ]);
+      addVariant('hocus', [
+        '@media (hover: hover) { &:is(:hover, :focus-visible) }',
+        '@media (hover: none) { &:focus-visible }',
+      ]);
+      addVariant('group-hocus', [
+        '@media (hover: hover) { .group:is(:hover, :focus-visible) & }',
+        '@media (hover: none) { .group:focus-visible & }',
+      ]);
+      addVariant('device-hover', '@media (hover: hover)');
+      addVariant('device-touch', '@media (hover: none)');
     }),
     plugin(({ addVariant, addBase, addUtilities }) => {
       addBase({
@@ -104,146 +114,14 @@ const config = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['var(--font-mplus-1p)', ...defaultTheme.fontFamily.sans],
+        sans: ['var(--font-source-sans)', 'var(--font-mplus-1)', ...defaultTheme.fontFamily.sans],
       },
       colors: {
         background: 'var(--background)',
         foreground: 'var(--foreground)',
       },
-      typography: (({ colors, theme }) => ({
-        'theme-override': {
-          css: {
-            '--tw-prose-links': colors.blue[600],
-            '--tw-prose-visited-links': colors.violet[600],
-            '--tw-prose-invert-links': colors.blue[500],
-            '--tw-prose-invert-visited-links': colors.violet[500],
-
-            '--tw-prose-body': colors.slate[800],
-            '--tw-prose-quote-borders': colors.slate[400],
-            '--tw-prose-hr': colors.slate[400],
-            '--tw-prose-bullets': colors.slate[500],
-
-            'ol:not([type])': { listStyleType: 'decimal' },
-            ':is(ul, ol) ol:not([type])': { listStyleType: 'lower-roman' },
-            ':is(ul, ol) :is(ul, ol) ol:not([type])': { listStyleType: 'lower-alpha' },
-            ':is(ul, ol) :is(ul, ol) :is(ul, ol) ol:not([type])': { listStyleType: 'decimal' },
-            'blockquote': {
-              fontStyle: 'inherit',
-              quotes: 'none',
-            },
-            // 'code:not(pre code)': {},
-            'code:not(pre code)::before': {
-              content: '"`"',
-            },
-            'code:not(pre code)::after': {
-              content: '"`"',
-            },
-          },
-        },
-        'invert': {
-          css: {
-            '--tw-prose-visited-links': 'var(--tw-prose-invert-visited-links)',
-          },
-        },
-        'relative-weight': {
-          css: {
-            'a': { fontWeight: 'inherit' },
-            'strong': { fontWeight: 'bolder' },
-            'ol > li::marker': { fontWeight: 'inherit' },
-            'dt': { fontWeight: 'bolder' },
-            'blockquote': { fontWeight: 'inherit' },
-            'h1': { fontWeight: 'bolder' },
-            'h2': { fontWeight: 'bolder' },
-            'h3': { fontWeight: 'bolder' },
-            'h4': { fontWeight: 'bolder' },
-            'kbd': { fontWeight: 'bolder' },
-            'code': { fontWeight: 'inherit' },
-            'pre': { fontWeight: 'inherit' },
-            'thead th': { fontWeight: 'bolder' },
-          },
-        },
-        'themed-weight': {
-          css: {
-            'a': { fontWeight: theme(key('500'), 'inherit') },
-            'strong': { fontWeight: theme(key('600'), 'inherit') },
-            'ol > li::marker': { fontWeight: theme(key('400'), 'inherit') },
-            'dt': { fontWeight: theme(key('600'), 'inherit') },
-            'blockquote': { fontWeight: theme(key('500'), 'inherit') },
-            'h1': { fontWeight: theme(key('800'), 'inherit') },
-            'h1 strong': { fontWeight: theme(key('900'), 'inherit') },
-            'h2': { fontWeight: theme(key('700'), 'inherit') },
-            'h2 strong': { fontWeight: theme(key('800'), 'inherit') },
-            'h3': { fontWeight: theme(key('600'), 'inherit') },
-            'h3 strong': { fontWeight: theme(key('700'), 'inherit') },
-            'h4': { fontWeight: theme(key('600'), 'inherit') },
-            'h4 strong': { fontWeight: theme(key('700'), 'inherit') },
-            'kbd': { fontWeight: theme(key('500'), 'inherit') },
-            'code': { fontWeight: theme(key('600'), 'inherit') },
-            'pre': { fontWeight: theme(key('400'), 'inherit') },
-            'thead th': { fontWeight: theme(key('600'), 'inherit') },
-          },
-        },
-        'DEFAULT': {
-          css: {
-            'a': {
-              color: `var(--tw-prose-links)`,
-            },
-            'a:hover': {
-              textDecoration: 'none',
-            },
-            'a:visited': {
-              color: `var(--tw-prose-visited-links, --tw-prose-links)`,
-            },
-          },
-        },
-      })) satisfies ResolvableTo<TypographyConfig>,
+      typography: typographyConfig,
     },
   },
 } satisfies Config;
 export default config;
-
-type TypographyConfig = Record<'DEFAULT' | string, { css: Partial<TypographyVariables> & Record<string, CSSProperties> }>;
-
-interface TypographyVariables extends CSSProperties {
-  '--tw-prose-body': string | number;
-  '--tw-prose-headings': string | number;
-  '--tw-prose-lead': string | number;
-  '--tw-prose-links': string | number;
-  '--tw-prose-bold': string | number;
-  '--tw-prose-counters': string | number;
-  '--tw-prose-bullets': string | number;
-  '--tw-prose-hr': string | number;
-  '--tw-prose-quotes': string | number;
-  '--tw-prose-quote-borders': string | number;
-  '--tw-prose-captions': string | number;
-  '--tw-prose-kbd': string | number;
-  '--tw-prose-kbd-shadows': string | number;
-  '--tw-prose-code': string | number;
-  '--tw-prose-pre-code': string | number;
-  '--tw-prose-pre-bg': string | number;
-  '--tw-prose-th-borders': string | number;
-  '--tw-prose-td-borders': string | number;
-  '--tw-prose-invert-body': string | number;
-  '--tw-prose-invert-headings': string | number;
-  '--tw-prose-invert-lead': string | number;
-  '--tw-prose-invert-links': string | number;
-  '--tw-prose-invert-bold': string | number;
-  '--tw-prose-invert-counters': string | number;
-  '--tw-prose-invert-bullets': string | number;
-  '--tw-prose-invert-hr': string | number;
-  '--tw-prose-invert-quotes': string | number;
-  '--tw-prose-invert-quote-borders': string | number;
-  '--tw-prose-invert-captions': string | number;
-  '--tw-prose-invert-kbd': string | number;
-  '--tw-prose-invert-kbd-shadows': string | number;
-  '--tw-prose-invert-code': string | number;
-  '--tw-prose-invert-pre-code': string | number;
-  '--tw-prose-invert-pre-bg': string | number;
-  '--tw-prose-invert-th-borders': string | number;
-  '--tw-prose-invert-td-borders': string | number;
-}
-
-interface TypographyVariables extends CSSProperties {
-  '--tw-prose-visited-links': string | number;
-  '--tw-prose-invert-visited-links': string | number;
-}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -144,7 +144,18 @@ const config = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['var(--font-source-sans)', 'var(--font-mplus-1)', ...defaultTheme.fontFamily.sans],
+        // kazesawa: [
+        //   ['var(--font-source-sans)', 'var(--font-mplus-1)', 'Kazesawa', ...defaultTheme.fontFamily.sans],
+        //   { fontFeatureSettings: "'palt'" },
+        // ],
+        sans: [
+          ['var(--font-noto-sans)', 'Yu Gothic', ...defaultTheme.fontFamily.sans],
+          { fontFeatureSettings: "'palt'" },
+        ],
+        // serif: [
+        //   ['var(--font-noto-serif)', 'Yu Mincho', ...defaultTheme.fontFamily.serif],
+        //   { fontFeatureSettings: "'palt'" },
+        // ],
       },
       colors: {
         background: 'var(--background)',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -31,22 +31,52 @@ const config = {
       },
     }),
     plugin(({ addVariant }) => {
-      addVariant('hover', [
-        '@media (hover: hover) { &:is(:hover, :focus-visible) }',
-        '@media (hover: none) { &:is(:active, :focus-visible) }',
+      // hover or focus-visible-within
+      const hover = 'is(:hover, :focus-visible, :has(:focus-visible))';
+      // active-within or focus-visible-within
+      const active = 'is(:active, :has(:active), :focus-visible, :has(:focus-visible))';
+      // focus-visible-within
+      const focus = 'is(:focus-visible, :has(:focus-visible))';
+
+      addVariant(`hover`, [
+        `@media (hover: hover) { &:${hover} }`,
+        `@media (hover: none) { &:${active} }`,
       ]);
-      addVariant('group-hover', [
-        '@media (hover: hover) { .group:is(:hover, :focus-visible) & }',
-        '@media (hover: none) { .group:is(:active, :focus-visible) & }',
+      addVariant(`group-hover`, [
+        `@media (hover: hover) { :merge(.group):${hover} & }`,
+        `@media (hover: none) { :merge(.group):${active} & }`,
       ]);
-      addVariant('hocus', [
-        '@media (hover: hover) { &:is(:hover, :focus-visible) }',
-        '@media (hover: none) { &:focus-visible }',
+      addVariant(`peer-hover`, [
+        `@media (hover: hover) { :merge(.peer):${hover} ~ & }`,
+        `@media (hover: none) { :merge(.peer):${active} ~ & }`,
       ]);
-      addVariant('group-hocus', [
-        '@media (hover: hover) { .group:is(:hover, :focus-visible) & }',
-        '@media (hover: none) { .group:focus-visible & }',
+      addVariant(`not-hover`, [
+        `@media (hover: hover) { &:not(:${hover}) }`,
+        `@media (hover: none) { &:not(:${active}) }`,
       ]);
+      addVariant(`group-not-hover`, [
+        `@media (hover: hover) { :merge(.group):not(:${hover}) & }`,
+        `@media (hover: none) { :merge(.group):not(:${active}) & }`,
+      ]);
+      addVariant(`peer-not-hover`, [
+        `@media (hover: hover) { :merge(.peer):not(:${hover}) ~ & }`,
+        `@media (hover: none) { :merge(.peer):not(:${active}) ~ & }`,
+      ]);
+      addVariant(`hocus`, [
+        `@media (hover: hover) { &:${hover} }`,
+        `@media (hover: none) { &:${focus} }`,
+      ]);
+      addVariant(`group-hocus`, [
+        `@media (hover: hover) { :merge(.group):${hover} & }`,
+        `@media (hover: none) { :merge(.group):${focus} & }`,
+      ]);
+      addVariant(`peer-hocus`, [
+        `@media (hover: hover) { :merge(.peer):${hover} ~ & }`,
+        `@media (hover: none) { :merge(.peer):${focus} ~ & }`,
+      ]);
+      addVariant('active', '&:is(:active, :has(:active))');
+      addVariant('group-active', ':merge(.group):is(:active, :has(:active)) &');
+      addVariant('peer-active', ':merge(.peer):is(:active, :has(:active)) ~ &');
       addVariant('device-hover', '@media (hover: hover)');
       addVariant('device-touch', '@media (hover: none)');
     }),

--- a/typography.config.ts
+++ b/typography.config.ts
@@ -1,0 +1,144 @@
+import defaultTheme from 'tailwindcss/defaultTheme';
+import { type ResolvableTo } from 'tailwindcss/types/config';
+import { type CSSProperties } from 'react';
+
+const key = (w: '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900') => {
+  const [name] = Object.entries(defaultTheme.fontWeight ?? {}).find(([, value]) => value === w) ?? ['normal'];
+  return `fontWeight.${name}`;
+};
+
+const typographyConfig = (({ colors, theme }) => ({
+  'theme-override': {
+    css: {
+      '--tw-prose-links': colors.blue[600],
+      '--tw-prose-visited-links': colors.violet[600],
+      '--tw-prose-invert-links': colors.blue[500],
+      '--tw-prose-invert-visited-links': colors.violet[500],
+
+      '--tw-prose-body': colors.slate[800],
+      '--tw-prose-quote-borders': colors.slate[400],
+      '--tw-prose-hr': colors.slate[400],
+      '--tw-prose-bullets': colors.slate[500],
+
+      'ol:not([type])': { listStyleType: 'decimal' },
+      ':is(ul, ol) ol:not([type])': { listStyleType: 'lower-roman' },
+      ':is(ul, ol) :is(ul, ol) ol:not([type])': { listStyleType: 'lower-alpha' },
+      ':is(ul, ol) :is(ul, ol) :is(ul, ol) ol:not([type])': { listStyleType: 'decimal' },
+      'blockquote': {
+        fontStyle: 'inherit',
+        quotes: 'none',
+      },
+      // 'code:not(pre code)': {},
+      'code:not(pre code)::before': {
+        content: '"`"',
+      },
+      'code:not(pre code)::after': {
+        content: '"`"',
+      },
+    },
+  },
+  'invert': {
+    css: {
+      '--tw-prose-visited-links': 'var(--tw-prose-invert-visited-links)',
+    },
+  },
+  'relative-weight': {
+    css: {
+      'a': { fontWeight: 'inherit' },
+      'strong': { fontWeight: 'bolder' },
+      'ol > li::marker': { fontWeight: 'inherit' },
+      'dt': { fontWeight: 'bolder' },
+      'blockquote': { fontWeight: 'inherit' },
+      'h1': { fontWeight: 'bolder' },
+      'h2': { fontWeight: 'bolder' },
+      'h3': { fontWeight: 'bolder' },
+      'h4': { fontWeight: 'bolder' },
+      'kbd': { fontWeight: 'bolder' },
+      'code': { fontWeight: 'inherit' },
+      'pre': { fontWeight: 'inherit' },
+      'thead th': { fontWeight: 'bolder' },
+    },
+  },
+  'themed-weight': {
+    css: {
+      'a': { fontWeight: theme(key('500'), 'inherit') },
+      'strong': { fontWeight: theme(key('600'), 'inherit') },
+      'ol > li::marker': { fontWeight: theme(key('400'), 'inherit') },
+      'dt': { fontWeight: theme(key('600'), 'inherit') },
+      'blockquote': { fontWeight: theme(key('500'), 'inherit') },
+      'h1': { fontWeight: theme(key('800'), 'inherit') },
+      'h1 strong': { fontWeight: theme(key('900'), 'inherit') },
+      'h2': { fontWeight: theme(key('700'), 'inherit') },
+      'h2 strong': { fontWeight: theme(key('800'), 'inherit') },
+      'h3': { fontWeight: theme(key('600'), 'inherit') },
+      'h3 strong': { fontWeight: theme(key('700'), 'inherit') },
+      'h4': { fontWeight: theme(key('600'), 'inherit') },
+      'h4 strong': { fontWeight: theme(key('700'), 'inherit') },
+      'kbd': { fontWeight: theme(key('500'), 'inherit') },
+      'code': { fontWeight: theme(key('600'), 'inherit') },
+      'pre': { fontWeight: theme(key('400'), 'inherit') },
+      'thead th': { fontWeight: theme(key('600'), 'inherit') },
+    },
+  },
+  'DEFAULT': {
+    css: {
+      'a': {
+        color: `var(--tw-prose-links)`,
+      },
+      'a:hover': {
+        textDecoration: 'none',
+      },
+      'a:visited': {
+        color: `var(--tw-prose-visited-links, --tw-prose-links)`,
+      },
+    },
+  },
+})) satisfies ResolvableTo<TypographyConfig>;
+
+export default typographyConfig;
+
+export type TypographyConfig = Record<'DEFAULT' | string, { css: Partial<TypographyVariables> & Record<string, CSSProperties> }>;
+
+interface TypographyVariables extends CSSProperties {
+  '--tw-prose-body': string | number;
+  '--tw-prose-headings': string | number;
+  '--tw-prose-lead': string | number;
+  '--tw-prose-links': string | number;
+  '--tw-prose-bold': string | number;
+  '--tw-prose-counters': string | number;
+  '--tw-prose-bullets': string | number;
+  '--tw-prose-hr': string | number;
+  '--tw-prose-quotes': string | number;
+  '--tw-prose-quote-borders': string | number;
+  '--tw-prose-captions': string | number;
+  '--tw-prose-kbd': string | number;
+  '--tw-prose-kbd-shadows': string | number;
+  '--tw-prose-code': string | number;
+  '--tw-prose-pre-code': string | number;
+  '--tw-prose-pre-bg': string | number;
+  '--tw-prose-th-borders': string | number;
+  '--tw-prose-td-borders': string | number;
+  '--tw-prose-invert-body': string | number;
+  '--tw-prose-invert-headings': string | number;
+  '--tw-prose-invert-lead': string | number;
+  '--tw-prose-invert-links': string | number;
+  '--tw-prose-invert-bold': string | number;
+  '--tw-prose-invert-counters': string | number;
+  '--tw-prose-invert-bullets': string | number;
+  '--tw-prose-invert-hr': string | number;
+  '--tw-prose-invert-quotes': string | number;
+  '--tw-prose-invert-quote-borders': string | number;
+  '--tw-prose-invert-captions': string | number;
+  '--tw-prose-invert-kbd': string | number;
+  '--tw-prose-invert-kbd-shadows': string | number;
+  '--tw-prose-invert-code': string | number;
+  '--tw-prose-invert-pre-code': string | number;
+  '--tw-prose-invert-pre-bg': string | number;
+  '--tw-prose-invert-th-borders': string | number;
+  '--tw-prose-invert-td-borders': string | number;
+}
+
+interface TypographyVariables extends CSSProperties {
+  '--tw-prose-visited-links': string | number;
+  '--tw-prose-invert-visited-links': string | number;
+}


### PR DESCRIPTION
スマホ等のタッチスクリーン端末ではホバーが出来ない。ヘッダーのリンクを押したときに、今まではホバー時は単に何もしていなかったが、`:active`を使用して下線を細くするように変更。

また、仮置きではあるがテーマ選択ボタンのスタイルをきちんとしたものへ。キーボード使用時にフォーカスしている要素がきちんと表示されるよう、`sr-only`にしていた`input`を`appearance-none`で隠すだけに変更。

ついでにコードブロックのテーマの問題も修正。fixes #18 